### PR TITLE
更新已经失效的外部链接

### DIFF
--- a/introduction/maillist.tex
+++ b/introduction/maillist.tex
@@ -3,7 +3,7 @@
 遇到问题，
 可以向这个邮件组的邮箱发送HELP邮件，该组内的所有成员都会收到你的邮件。
 如果某人知道答案，他或许就会给你回复。发现了SAC的bug也可以向这里报告，开发者会尽快给你回复的。
-当然问问题之前要思考\footnote{请阅读《提问的智慧》\url{http://www.wapm.cn/smart-questions/smart-questions-zh.html}}，
+当然问问题之前要思考，可阅读《提问的智慧》\footnote{参考译文：\url{http://doc.zengrong.net/smart-questions/cn.html}；有SAC方面的问题，请勿向《提问的智慧》的译者提问！}，
 提交bug的时候要详细指出bug是如何出现的，也可以给出代码或文件以使得开发者能够重现该bug。
 
 邮件组邮箱~:~\url{sac-help@iris.washington.edu}


### PR DESCRIPTION
原来的链接已经404
我找了一个新的链接：http://doc.zengrong.net/smart-questions/cn.html
这个译文作者的『弃权申明』中要求：加上一句『我们不提供该项目的服务支持！』（这里的我们是译文作者），所以我加了一句：『有SAC方面的问题，请勿向《提问的智慧》的译者提问！』
