### PR TITLE
Fix CJK spacing issues due to newlines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.5.0
 sphinx_rtd_theme
-hanzi
+zhon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=1.5.0
 sphinx_rtd_theme
+hanzi

--- a/source/_extensions/cjkspacing.py
+++ b/source/_extensions/cjkspacing.py
@@ -1,0 +1,42 @@
+# Inspired by https://blog.csdn.net/ancale/article/details/27982553
+from zhon.hanzi import punctuation as CJK_PUNCTUATION
+from docutils.nodes import *
+
+
+def setup(app):
+    app.connect('doctree-resolved', process_chinese_paragraph)
+
+
+def cjkspacing(text):
+    '''Fix spacing issue related to newlines of CJK characters.
+
+    The idea is to split input text by newlines and then join them to a string.
+
+    Some exceptions are:
+
+    '''
+    # split input text into lines
+    lines = text.splitlines()
+    # deal with exceptions
+    for i in range(1, len(lines)):  # start from 1
+        # current line starts with ASCII and last line starts with hanzi
+        try:
+            if ord(lines[i][0]) < 128 and lines[i-1][-1] not in CJK_PUNCTUATION:
+                lines[i] = " " + lines[i]
+        except:
+            pass
+    text = "".join(lines)
+    return text
+
+
+class ParagraphVisitor(NodeVisitor):
+    def dispatch_visit(self, node):
+        if isinstance(node, paragraph):
+            for i in range(len(node.children)):
+                if type(node[i]) == Text:
+                    node[i] = Text(cjkspacing(node[i].astext()))
+
+
+def process_chinese_paragraph(app, doctree, docname):
+    pv = ParagraphVisitor(doctree)
+    doctree.walk(pv)

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+import sys
+sys.path.insert(0, os.path.abspath('_extensions'))
+
 # -- General configuration ------------------------------------------------
-
-# If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = ['sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages']
+    'sphinx.ext.githubpages',
+    'cjkspacing']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Fixes #120.

基本原理：遍历文档中所有段落，用 `splitlines()` 将段落按照换行符分割成列表，然后将列表用 `join()` 连接起来。

例外情况：

1. 某行以英文开头且上一行以中文结尾：需要加上空格
2. 某行以英文开头但上一行以中文标点结尾：不需要加上空格

目前没有考虑到所有可能的情况，也没有经过严谨测试，速度上似乎基本不影响。