### PR TITLE
Change code-block to console [step 1]

### DIFF
--- a/source/commands/about.rst
+++ b/source/commands/about.rst
@@ -9,6 +9,6 @@ about
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ABOUT

--- a/source/commands/abs.rst
+++ b/source/commands/abs.rst
@@ -9,7 +9,7 @@ abs
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ABS
 

--- a/source/commands/add.rst
+++ b/source/commands/add.rst
@@ -9,7 +9,7 @@ add
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     add [v1 [v2 ... vn]]
 
@@ -28,7 +28,7 @@ vn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     add 0.0
 
@@ -47,7 +47,7 @@ vn
 
 为了给文件 f1 的每个数据点加上常数 5.1，f2 和 f3 的每个数据点加上常数 6.2：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r f1 f2 f3         # 三个文件
     SAC> add 5.1 6.2        # 两个常数

--- a/source/commands/addf.rst
+++ b/source/commands/addf.rst
@@ -9,7 +9,7 @@ addf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ADDF [Newhdr [ON|OFF]] filelist
 
@@ -57,14 +57,14 @@ A 的文件，C 是两个文件相加的结果。该命令会将磁盘中的一�
 
 将一个文件加到其他三个文件中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2 file3
     SAC> addf file4
 
 将两个文件分别加到另两个文件中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2
     SAC> addf file3 file4

--- a/source/commands/apk.rst
+++ b/source/commands/apk.rst
@@ -9,7 +9,7 @@ apk
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     APK [param v [param v] ... ] [Validation ON|OFF]
 
@@ -25,7 +25,7 @@ VALIDATION ON/OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     apk c1 0.985 c2 3.0 c3 0.6 c4 0.03 c5 5.0 c6 0.0039 c7 100. c8 -0.1
         d5 2. d8 3. d9 1. i3 3 i4 40 i6 3 validation on
@@ -72,7 +72,7 @@ VALIDATION ON/OFF
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seis                # 利用这个数据做个例子
     SAC> lh a                   # 这个数据本身是标有 A 的，即初动到时

--- a/source/commands/arraymap.rst
+++ b/source/commands/arraymap.rst
@@ -9,7 +9,7 @@ arraymap
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ARRAYmap [Array|Coarray]
 
@@ -25,7 +25,7 @@ COARRAY
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     arraymap array
 

--- a/source/commands/axes.rst
+++ b/source/commands/axes.rst
@@ -9,7 +9,7 @@ axes
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     AXES [ON|OFF|ONLy] [All] [Top] [Bottom] [Right] [Left]
 
@@ -43,7 +43,7 @@ LEFT
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     axes only bottom left
 
@@ -67,7 +67,7 @@ LEFT
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seis
     SAC> p           # 看看 SAC 的默认设置，左边和底部有注释

--- a/source/commands/bandpass.rst
+++ b/source/commands/bandpass.rst
@@ -9,7 +9,7 @@ bandpass
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BandPass [BUtter|BEssel|C1|C2] [Corners v1 v2] [Npoles n] [Passes n]
         [Tranbw v] [Atten v]
@@ -47,7 +47,7 @@ ATTEN v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     bandpass butter corner 0.1 0.4 npoles 2 passes 1 tranbw 0.3 atten 30
 
@@ -104,13 +104,13 @@ Chebyshev 滤波器设计起来更复杂一点，除了截止频率和极点数�
 
 应用一个四极 Butterworth 滤波器，拐角频率为 2 Hz 和 5 Hz：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> bp n 4 c 2 5
 
 在此之后如果要应用一个二极双通具有相同频率的 Bessel：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> bp n 2 be p 2
 

--- a/source/commands/bandrej.rst
+++ b/source/commands/bandrej.rst
@@ -9,7 +9,7 @@ bandrej
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BandRej [BUtter|BEssel|C1|C2] [Corners v1 v2] [Npoles n] [Passes n]
         [Tranbw v] [Atten v]
@@ -47,7 +47,7 @@ ATTEN v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     bandrej butter corner 0.1 0.4 npoles 2 passes 1 tranbw 0.3 atten 30
 
@@ -61,13 +61,13 @@ ATTEN v
 
 应用一个四极 Butterworth 滤波器，拐角频率为 2 Hz 和 5 Hz：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> br n 4 c 2 5
 
 在此之后如果要应用一个二极双通具有相同频率的 Bessel：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> br n 2 be p 2
 

--- a/source/commands/bbfk.rst
+++ b/source/commands/bbfk.rst
@@ -9,7 +9,7 @@ bbfk
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BBFK [Filter] [NOrmalize] [EPS v] [MLM|PDS] [Exp n] [WAwvenumber v]
         [Size m n] [Levels n] [Db] [Title text] [WRite [ON|OFF fname] [Ssq n]]
@@ -63,7 +63,7 @@ SSQ n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     bbfk eps .01 pds exp 1 wvenumber 1.0 size 90 32 levels 11
         write off ssq 100

--- a/source/commands/beam.rst
+++ b/source/commands/beam.rst
@@ -9,7 +9,7 @@ beam
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BEAM [Bearing v] [Velocity v] [REFerence ON|OFF| lat lon [el]]
         [OFFSET REF|USER|STATION|EVENT|CASCADE] [Ec anginc survel]
@@ -66,7 +66,7 @@ WRITE fname
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     beam  b 90  v 9.0 ec 33  6.0 c  0. 0. 0. w BEAM
 

--- a/source/commands/begindevices.rst
+++ b/source/commands/begindevices.rst
@@ -9,7 +9,7 @@ begindevices
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BeginDevices Sgf|Xwindows
 

--- a/source/commands/beginframe.rst
+++ b/source/commands/beginframe.rst
@@ -9,7 +9,7 @@ beginframe
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BeginFrame
 

--- a/source/commands/beginwindow.rst
+++ b/source/commands/beginwindow.rst
@@ -9,7 +9,7 @@ beginwindow
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BeginWindow n
 
@@ -22,7 +22,7 @@ n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     beginwindow 1
 

--- a/source/commands/benioff.rst
+++ b/source/commands/benioff.rst
@@ -9,7 +9,7 @@ benioff
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BENIOFF
 

--- a/source/commands/binoperr.rst
+++ b/source/commands/binoperr.rst
@@ -10,7 +10,7 @@ binoperr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BINOPERR [Npts Fatal|Warning|Ignore] [Delta Fatal|Warning|Ignore]
 
@@ -37,7 +37,7 @@ IGNORE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     binoperr npts fatal delta fatal
 
@@ -67,7 +67,7 @@ IGNORE
 
 假定 file1 有1000个数据点，file2 有950个数据点：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> binoperr npts fatal
     SAC> read file1
@@ -76,7 +76,7 @@ IGNORE
 
 上例中由于数据点数不匹配导致文件加法未执行，假设你输入：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> binoperr npts warning
     SAC> addf file2

--- a/source/commands/border.rst
+++ b/source/commands/border.rst
@@ -9,7 +9,7 @@ border
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     BORDER [ON|OFF]
 
@@ -22,7 +22,7 @@ ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     border off
 

--- a/source/commands/capf.rst
+++ b/source/commands/capf.rst
@@ -9,6 +9,6 @@ capf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CAPF

--- a/source/commands/chnhdr.rst
+++ b/source/commands/chnhdr.rst
@@ -9,7 +9,7 @@ chnhdr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ChnHdr [FILE n1 n2 ...] field v [field v ...] [ALLT v]
 
@@ -61,21 +61,21 @@ ALLT v
 
 修改内存中所有文件的事件经纬度、事件名：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ch evla 34.3 evlo -118.5
     SAC> ch kevnm 'LA goes under'
 
 修改第二、四个文件的事件经纬度、事件名：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ch file 2 4 EVLA 34.3 EVLO -118.5
     SAC> ch file 2 4 KEVNM 'LA goes under'
 
 设定初动到时为无定义状态：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ch a undef
 
@@ -85,13 +85,13 @@ ALLT v
 
 首先用 ``GMT`` 选项设置事件起始时间：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ch o GMT 1982 123 13 37 10 103
 
 现在使用 :doc:`/commands/listhdr` 检查发震时刻 ``o`` 相对于当前参考时间的秒数：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh o
      o = 123.103
@@ -99,7 +99,7 @@ ALLT v
 现在使用 ``ALLT`` 选项从所有的偏移时间中减去这个值，并加到参考时间上，
 同时需要改变描述参考时间类型的字段：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ch allt -123.103 iztype iO
 
@@ -107,7 +107,7 @@ ALLT v
 
 更方便的做法是直接引用头段变量的值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ch allt (0 - &1,o&) iztype IO
 

--- a/source/commands/chpf.rst
+++ b/source/commands/chpf.rst
@@ -9,7 +9,7 @@ chpf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CHPF
 

--- a/source/commands/color.rst
+++ b/source/commands/color.rst
@@ -9,14 +9,14 @@ color
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     COLor [ON|OFF|color] [Increment [ON|OFF]] [Skeleton color] [Background color]
         [List Standard|colorlist]
 
 color 是下面中的一个：
 
-.. code-block:: bash
+.. code-block:: console
 
     White|Red|Green|Yellow|BLUe|Magenta|Cyan|BLAck
 
@@ -56,7 +56,7 @@ LIST STANDARD
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     color black increment off skeleton black background white list standard
 
@@ -85,19 +85,19 @@ LIST STANDARD
 
 为了使数据颜色从红色开始不断变换：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> color red increment
 
 为了设置数据颜色为红色，背景白色，蓝色边框：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> color red background white skeleton blue
 
 为了设置一个数据颜色不断变换，颜色列表为 red、white、blue，背景色为 aquamarine：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> color red increment backgroud 47 list red white blue
 

--- a/source/commands/comcor.rst
+++ b/source/commands/comcor.rst
@@ -9,14 +9,14 @@ comcor
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     COMCOR [ON|OFF]
 
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     comcor off
 
@@ -29,7 +29,7 @@ ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     comcor off
 

--- a/source/commands/contour.rst
+++ b/source/commands/contour.rst
@@ -9,7 +9,7 @@ contour
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CONTour [Aspect ON|OFF]
 
@@ -26,7 +26,7 @@ ASPECT OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     contour aspect off
 

--- a/source/commands/convert.rst
+++ b/source/commands/convert.rst
@@ -9,7 +9,7 @@ convert
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CONVert [FROM] [format] infile [TO [format] outfile]|[OVER [format]]
 
@@ -31,7 +31,7 @@ format
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     convert from sac infile over sac
 

--- a/source/commands/convolve.rst
+++ b/source/commands/convolve.rst
@@ -9,7 +9,7 @@ convolve
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CONVOlve [Master name|n] [Number n] [Length ON|OFF|v]
         [Type Rectangle|HAMming|HANning|Cosine|Triangle]
@@ -38,7 +38,7 @@ TYPE HAMMING|HANNING|COSINE|TRIANGlE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     convolve master 1 number 1 length off type rectangle
 

--- a/source/commands/copyhdr.rst
+++ b/source/commands/copyhdr.rst
@@ -9,7 +9,7 @@ copyhdr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     COPYHDR [FROM name|n] hdrlist
 
@@ -28,7 +28,7 @@ hdrlist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     copyhdr from 1
 
@@ -44,7 +44,7 @@ hdrlist
 假设你使用 ``ppk`` 命令在文件 FILE1 中标记了多个时间，并将其储存到
 头段变量 ``T3`` 和 ``T4`` 中。为了将这些时间标记复制到到 FILE2 和 FILE3 中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r FILE1
     SAC> ppk
@@ -55,6 +55,6 @@ hdrlist
 假设你读取了很多文件，想要复制文件 ABC 中的头段变量 ``evla`` 和 ``evlo``
 到其他所有文件中去，这时使用文件名而非数字会更简单：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> copyhdr from abc stla stlo

--- a/source/commands/correlate.rst
+++ b/source/commands/correlate.rst
@@ -9,7 +9,7 @@ correlate
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CORrelate [Master name|n] [Number n] [Length ON|OFF|v] [NOrmalized]
         [Type Rectangle|HAMming|HANning|Cosine|Triangle]
@@ -47,7 +47,7 @@ TYPE TRIANGLE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     correlate master 1 number 1 length off type rectangle
 
@@ -81,7 +81,7 @@ TYPE TRIANGLE
 
 以内存中第三个文件为主文件计算互相关函数：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2 file3
     SAC> cor master 3
@@ -91,7 +91,7 @@ TYPE TRIANGLE
 假设有两个数据文件，每个包含1000个噪声数据。将数据划分为无重叠的10个窗，
 每个窗包含100个数据点，且对窗应用 hanning 函数，并计算10个窗的平均相关函数：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2
     SAC> cor type hanning number 10
@@ -99,14 +99,14 @@ TYPE TRIANGLE
 为了使窗之间有20%的混叠，可以设置窗长度为120个数据点。假设数据采样周期
 为0.025（即每秒40个采样点），则窗长为3秒：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2
     SAC> cor type hanning number 10 length 3.0
 
 下面的例子计算了两个数据之间的归一化互相关函数，并从中提取出了互相关系数：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2
     SAC> cor norm                                   # 归一化互相关

--- a/source/commands/cut.rst
+++ b/source/commands/cut.rst
@@ -9,7 +9,7 @@ cut
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CUT [ON|OFF|pdw|SIGNAL]
 
@@ -32,7 +32,7 @@ SIGNAL
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     cut off
 
@@ -62,14 +62,14 @@ SIGNAL
 下面将用一系列示例来展示 ``cut`` 命令的常见用法。首先，先生成测试用
 的示例数据：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seis
     SAC> w seismo.sac
 
 直接读取文件，不做任何截窗操作：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r seismo.sac
     SAC> lh b e a kztime npts
@@ -81,7 +81,7 @@ SIGNAL
 
 截取 b 到 e 之间的波形，等效于不做任何截窗操作：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut b e
     SAC> r seismo.sac
@@ -94,7 +94,7 @@ SIGNAL
 
 截取文件的前3秒：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut b 0 3
     SAC> r seismo.sac
@@ -107,7 +107,7 @@ SIGNAL
 
 截取文件开始的100个数据点：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut b n 100
     SAC> r
@@ -120,7 +120,7 @@ SIGNAL
 
 截取初动前0.5秒到初动后3秒的数据：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut a -0.5 3
     SAC> r
@@ -133,7 +133,7 @@ SIGNAL
 
 截取数据的第10到15秒（相对于参考时刻）：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut 10 15
     SAC> r ./seismo.sac
@@ -146,7 +146,7 @@ SIGNAL
 
 先截取数据的最开始前3秒，再截取接下来的3秒：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut b 0 3
     SAC> r ./seismo.sac
@@ -178,7 +178,7 @@ SIGNAL
 当要截取的窗超过了文件的时间范围时，可以使用 :doc:`/commands/cuterr` 命令的
 ``FILLZ`` 选项，在文件的开始或结尾处补0，再读入内存。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r N11A.lhz
     SAC> lh npts

--- a/source/commands/cuterr.rst
+++ b/source/commands/cuterr.rst
@@ -9,7 +9,7 @@ cuterr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CUTERR FAtal|Usebe|FIllz
 
@@ -44,7 +44,7 @@ FILLZ
 
 假设文件 FILE1 起始时间为B=25 s，初动到时A=40 s，采样率为 0.01 s。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut a 20 e
     SAC> read file1

--- a/source/commands/cutim.rst
+++ b/source/commands/cutim.rst
@@ -9,7 +9,7 @@ cutim
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     CUTIM pdw [pdw ... ]
 
@@ -42,7 +42,7 @@ pdw
 
 下面的宏文件展示了 ``cutim`` 命令的常见用法：
 
-.. code-block:: bash
+.. code-block:: console
 
     fg seismo
     echo on

--- a/source/commands/datagen.rst
+++ b/source/commands/datagen.rst
@@ -9,7 +9,7 @@ datagen
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DataGen [MORE] [SUB Local|Regional|Teleseis] [filelist]
 
@@ -47,7 +47,7 @@ LLSN 拥有一系列垂直分量和三分量台站。该数据集中包含了9�
 数据时长40秒，每秒100个采样点。台站信息、事件信息、p波及尾波到时都包含在
 头段中，这些文件包括：
 
-.. code-block:: bash
+.. code-block:: console
 
         cal.z, cal.n, cal.e
         cao.z, cao.n, cao.e
@@ -66,7 +66,7 @@ REGIONAL
 美国西部的四个宽频带三分量台站。数据包含了从发震前5秒开始的为300秒地震
 数据，每秒含40个采样点，文件名为：
 
-.. code-block:: bash
+.. code-block:: console
 
         elk.z, elk.n, elk.e
         lac.z, lac.n, lac.e
@@ -82,7 +82,7 @@ Test Network (RSTN) 的5个台站的中等周期和长周期数据（其中cpk�
 无法获取，sdk 台站的长周期数据被截断）。这个数据集的数据时长1600秒，长周
 期数据每秒1个采样点，中等周期数据每秒4个采样点。文件包括：
 
-.. code-block:: bash
+.. code-block:: console
 
         ntkl.z, ntkl.n, ntkl.e, ntkm.z, ntkm.n, ntkm.e
         nykl.z, nykl.n, nykl.e, nykm.z, nykm.n, nykm.e
@@ -94,7 +94,7 @@ Test Network (RSTN) 的5个台站的中等周期和长周期数据（其中cpk�
 
 下面的示例展示了一些基本的用法：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> dg sub l cal.z    # 单个近震 Z 分量数据
     SAC> dg sub r *.z      # 区域地震多台 Z 分量数据
@@ -102,7 +102,7 @@ Test Network (RSTN) 的5个台站的中等周期和长周期数据（其中cpk�
 
 生成一堆波形数据，并保存数据到磁盘中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> dg sub l cdv.e cdv.n cdv.z
     SAC> w cdv.e cdv.n cdv.z
@@ -110,7 +110,7 @@ Test Network (RSTN) 的5个台站的中等周期和长周期数据（其中cpk�
 在写文件时，需要手动指定文件名列表，当文件很多时，就会变得很麻烦。可以
 利用 :doc:`/commands/write`  命令的语法简化这一命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> dg sub local *
     SAC> w delete /opt/sac/aux/datagen/local/

--- a/source/commands/decimate.rst
+++ b/source/commands/decimate.rst
@@ -9,7 +9,7 @@ decimate
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DECimate [n] [Filter ON|OFF]
 
@@ -25,7 +25,7 @@ FILTER ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     decimate 2 filter on
 
@@ -56,7 +56,7 @@ FILTER ON|OFF
 
 对数据减采样42倍：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1
     SAC> decimate 7     # 减采样因子为7时 FIR 滤波器偶尔不稳定，慎用！

--- a/source/commands/deletechannel.rst
+++ b/source/commands/deletechannel.rst
@@ -9,13 +9,13 @@ deletechannel
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DeleteChannel ALL
 
 或
 
-.. code-block:: bash
+.. code-block:: console
 
     DeleteChannel fname|fno|range [fname|fno|range ...]
 
@@ -37,7 +37,7 @@ range
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
       dc 3 5                         # 删除第3、5个文件
       dc SO01.sz SO02.sz             # 删除这些名字的文件

--- a/source/commands/dif.rst
+++ b/source/commands/dif.rst
@@ -9,7 +9,7 @@ dif
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DIF [TWo|THree|Five]
 
@@ -28,7 +28,7 @@ FIVE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     dif two
 

--- a/source/commands/div.rst
+++ b/source/commands/div.rst
@@ -9,7 +9,7 @@ div
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DIV [v1 [v2 ... vn] ]
 
@@ -28,7 +28,7 @@ vn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     div 1.0
 

--- a/source/commands/divf.rst
+++ b/source/commands/divf.rst
@@ -9,7 +9,7 @@ divf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DIVF [NEWHDR [ON|OFF]] filelist
 

--- a/source/commands/divomega.rst
+++ b/source/commands/divomega.rst
@@ -9,7 +9,7 @@ divomega
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     DIVOMEGA
 
@@ -48,7 +48,7 @@ Fourier 变换，用此命令在频率域积分可以去除时间域微分的效
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1
     SAC> dif                # 微分预白化

--- a/source/commands/echo.rst
+++ b/source/commands/echo.rst
@@ -9,7 +9,7 @@ echo
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ECHO ON|OFF Errors|Warnings|Output|Commands|Macros|Process
 
@@ -41,7 +41,7 @@ PROCESSED
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     echo on errors warnings output off commands macros processed
 

--- a/source/commands/enddevices.rst
+++ b/source/commands/enddevices.rst
@@ -9,7 +9,7 @@ enddevices
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     EndDevices [ALL|Sgf|Xwindows]
 

--- a/source/commands/endframe.rst
+++ b/source/commands/endframe.rst
@@ -9,7 +9,7 @@ endframe
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     EndFrame
 

--- a/source/commands/envelope.rst
+++ b/source/commands/envelope.rst
@@ -9,7 +9,7 @@ envelope
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ENVELOPE
 

--- a/source/commands/erase.rst
+++ b/source/commands/erase.rst
@@ -9,7 +9,7 @@ erase
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ERAse
 

--- a/source/commands/evaluate.rst
+++ b/source/commands/evaluate.rst
@@ -9,13 +9,13 @@ evaluate
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     EVALuate [TO TERM|name] [v] op v [op v ...]
 
 其中 ``op`` 可以取下面中的一个：
 
-.. code-block:: bash
+.. code-block:: console
 
     ADD|SUBTRACT|MULTIPLY|DIVIDE|POWER|SQRT|EXP|ALOG|ALOG10|
     SIN|ASIN|COS|ACOS|TAN|ATAN|EQ|NE|LE|GE|LT|GT
@@ -41,7 +41,7 @@ op
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     evaluate to term 1. * 1.
 
@@ -58,7 +58,7 @@ op
 
 一个简单的例子：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> eval 2*3
      6
@@ -67,7 +67,7 @@ op
 
 下面将一个以度为单位的角度转换为弧度并计算其正切值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> eval 45*pi/180
      0.785398
@@ -76,7 +76,7 @@ op
 
 下面将计算的结果保存到黑板变量：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> evaluate to temp1 45*pi/180
     SAC> evaluate tan %temp1%

--- a/source/commands/exp.rst
+++ b/source/commands/exp.rst
@@ -9,7 +9,7 @@ exp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     EXP
 

--- a/source/commands/exp10.rst
+++ b/source/commands/exp10.rst
@@ -9,7 +9,7 @@ exp10
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     EXP10
 

--- a/source/commands/fft.rst
+++ b/source/commands/fft.rst
@@ -9,7 +9,7 @@ fft
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FFT [WOmean|Wmean] [Rlim|Amph]
 
@@ -31,7 +31,7 @@ AMPH
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     fft wmean amph
 
@@ -57,7 +57,7 @@ AMPH
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seis
     SAC> lh b e delta npts iftype

--- a/source/commands/fileid.rst
+++ b/source/commands/fileid.rst
@@ -9,7 +9,7 @@ fileid
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FILEID [ON|OFF] [Type Default|Name|List hdrlist] [Location UR|UL|LR|LL]
         [Format Equals|Colons|Nonames]
@@ -47,7 +47,7 @@ FORMAT NONAMES
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     fileid on type default location ur format nonames
 
@@ -64,26 +64,26 @@ FORMAT NONAMES
 
 将文件名放在左上角：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fileid location ul type name
 
 定义一个特殊的文件 id，包含台站分量、经纬度：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fileid type list kstcmp stla stlo
 
 文件 id 为头段名后加一个冒号：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fileid format colons
 
 需要强调的是 fileid 命令有 bug，type 不能和 location、format 同时设置，
 必须分开设置，一个设置 type，另一个设置 location 和 format：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fileid type list knetwk kstnm
     SAC> fileid location ul format colons

--- a/source/commands/filenumber.rst
+++ b/source/commands/filenumber.rst
@@ -9,14 +9,14 @@ filenumber
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FileNumber [ON|OFF]
 
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     filenumber off
 

--- a/source/commands/filterdesign.rst
+++ b/source/commands/filterdesign.rst
@@ -9,7 +9,7 @@ filterdesign
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FilterDesign [FILE [prefix]] [filteroptions] [delta]
 
@@ -69,6 +69,6 @@ Hz。\ ``prefix.imp`` 是时间序列文件，包含脉冲响应信息。
 下面的例子展示了如何使用 ``filterdesign`` 命令产生一个高通，拐角频率为 2 Hz，
 六极、双通滤波器的数字和模拟响应曲线，数据采样间隔为 0.025 s：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fd hp c 2 n 6 p 2 delta .025

--- a/source/commands/fir.rst
+++ b/source/commands/fir.rst
@@ -9,7 +9,7 @@ fir
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FIR [REC|FFT] file
 
@@ -28,7 +28,7 @@ file
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     fir fft fir
 

--- a/source/commands/floor.rst
+++ b/source/commands/floor.rst
@@ -9,7 +9,7 @@ floor
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FLOOR [ON|OFF|v]
 
@@ -28,7 +28,7 @@ v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     floor 1.0e-10
 

--- a/source/commands/funcgen.rst
+++ b/source/commands/funcgen.rst
@@ -9,13 +9,13 @@ funcgen
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     FuncGen [type] [Delta v] [Npts n] [BEgin v]
 
 其中 ``type`` 是下面中的一个：
 
-.. code-block:: bash
+.. code-block:: console
 
     IMPulse | STep | Boxcar | Triangle | SINE [v1 v2] | Line [v1 v2] |
     Quadratic [v1 v2 v3] | CUBIC [v1 v2 v3 v4] | SEISmogram |
@@ -76,7 +76,7 @@ BEGIN v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     funcgen impulse npts 100 delta 1.0 begin 0.
 
@@ -94,6 +94,6 @@ BEGIN v
 
 下面的命令可以用于生成一个随机白噪声：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg random 1 1 npts 10000 delta 0.01

--- a/source/commands/getbb.rst
+++ b/source/commands/getbb.rst
@@ -9,7 +9,7 @@ getbb
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     GETBB [TO TERMinal|filename] [NAMES ON|OFF] [NEWLINE ON|OFF]
         ALL|variable [variable ...]
@@ -44,7 +44,7 @@ variable
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     getbb to terminal names on newline on all
 
@@ -61,13 +61,13 @@ variable
 
 假设你已经设置了一些黑板变量：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> setbb c1 2.45 c2 4.94
 
 稍后可以这样打印他们的值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> getbb c1 c2
      c1 = 2.45
@@ -75,7 +75,7 @@ variable
 
 想要在一行内只打印其值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> getbb names off newline off c1 c2
      2.45 4.94
@@ -85,7 +85,7 @@ variable
 保存每对X和Y的值，然后绘图。下面的宏文件的第一个参数是用于储存这些结果的
 文本文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     DO FILE WILD *Z
       READ FILE

--- a/source/commands/grayscale.rst
+++ b/source/commands/grayscale.rst
@@ -9,7 +9,7 @@ grayscale
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     GrayScale [VIDEOTYPE NORMAL|REVERSED] [SCALE v] [ZOOM n]
         [XCROP n1 n2|ON|OFF] [YCROP n1 n2|ON|OFF]
@@ -59,7 +59,7 @@ YCROP OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     grayscale videotype normal scale 1.0 zoom 1 xcrop off ycrop off
 

--- a/source/commands/grid.rst
+++ b/source/commands/grid.rst
@@ -9,7 +9,7 @@ grid
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     GRID [ON|OFF|Solid|Dotted]
 
@@ -31,7 +31,7 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     grid off
 

--- a/source/commands/gtext.rst
+++ b/source/commands/gtext.rst
@@ -9,7 +9,7 @@ gtext
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     GText [Software|Hardware] [Font n] [SIZE size] [SYStem system] [Name name]
 
@@ -40,7 +40,7 @@ NAME name
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     gtext software font 1 size small
 
@@ -63,6 +63,6 @@ complex italics、triplex block、riplex italics。
 
 选择 triplex 软件字体：
 
-.. code-block:: bash
+.. code-block:: console
 
     SCA> gtext software font 6

--- a/source/commands/hanning.rst
+++ b/source/commands/hanning.rst
@@ -9,7 +9,7 @@ hanning
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     HANning
 

--- a/source/commands/help.rst
+++ b/source/commands/help.rst
@@ -9,7 +9,7 @@ help
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Help [item ... ]
 
@@ -30,7 +30,7 @@ SAC 的官方帮助文档位于 ``$SACHOME/aux/help`` 目录中，该命令实�
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> h                  # 获得帮助文档包的介绍
     SAC> h r cut bd p       # 一次显示多个命令的文档

--- a/source/commands/highpass.rst
+++ b/source/commands/highpass.rst
@@ -9,7 +9,7 @@ highpass
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     HighPass [BUtter|BEssel|C1|C2] [Corners v1 v2] [Npoles n] [Passes n]
         [Tranbw v] [Atten v]
@@ -47,7 +47,7 @@ ATTEN v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     highpass butter corner 0.2 npoles 2 passes 1 tranbw 0.3 atten 30
 
@@ -61,13 +61,13 @@ ATTEN v
 
 应用一个四极 Butterworth，拐角频率为 2 Hz：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> hp n 4 c 2
 
 在此之后如果要应用一个二极双通具有相同频率的 Bessel：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> hp n 2 be p 2
 

--- a/source/commands/hilbert.rst
+++ b/source/commands/hilbert.rst
@@ -9,7 +9,7 @@ hilbert
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     HILBERT
 

--- a/source/commands/history.rst
+++ b/source/commands/history.rst
@@ -9,7 +9,7 @@ history
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     HISTORY
 
@@ -28,30 +28,30 @@ history
 
 打印命令历史列表：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> history
 
 重复命令1：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> !1
 
 重复最后一条命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> !!
 
 重复倒数第二个命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> !-2
 
 重复以 ``ps`` 开头的命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> !ps

--- a/source/commands/ifft.rst
+++ b/source/commands/ifft.rst
@@ -9,7 +9,7 @@ ifft
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     IFFT
 

--- a/source/commands/image.rst
+++ b/source/commands/image.rst
@@ -9,7 +9,7 @@ image
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     IMAGE [COLOR|GREY] [BINARY|FULL]
 
@@ -25,7 +25,7 @@ BINARY|FULL
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     image color full
 
@@ -44,7 +44,7 @@ BINARY|FULL
 
 以 SAC v101.5c 自带的 contourdata 为例：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r contourdata
     SAC> image

--- a/source/commands/inicm.rst
+++ b/source/commands/inicm.rst
@@ -9,7 +9,7 @@ inicm
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     INICM
 

--- a/source/commands/installmacro.rst
+++ b/source/commands/installmacro.rst
@@ -9,7 +9,7 @@ installmacro
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     INSTALLMACRO name [name ...]
 

--- a/source/commands/int.rst
+++ b/source/commands/int.rst
@@ -9,14 +9,14 @@ int
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     INT [Trapezeidal|Rectangular]
 
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     int trapezoidal
 

--- a/source/commands/interpolate.rst
+++ b/source/commands/interpolate.rst
@@ -9,7 +9,7 @@ interpolate
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     INTERPolate [Delta v|Npts v] [Begin v]
 
@@ -48,7 +48,7 @@ BEGIN v
 
 假定 filea 是等间隔数据，采样间隔为 0.025 s，为了将转换到采样间隔为 0.02 s：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r filea
     SAC> interp delta 0.02
@@ -57,14 +57,14 @@ BEGIN v
 
 假定 fileb 数据点数为3101，想要保持其时间跨度，并采样至4096个点：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r fileb
     SAC> interp npts 4096
 
 假设 filec 是不等间隔数据，为了将其转换为采样率为 0.01 s 的等间隔数据：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read filec
     SAC> interpolate delta 0.01

--- a/source/commands/keepam.rst
+++ b/source/commands/keepam.rst
@@ -9,7 +9,7 @@ keepam
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     keepAM
 

--- a/source/commands/khronhite.rst
+++ b/source/commands/khronhite.rst
@@ -9,7 +9,7 @@ khronhite
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     KHRONHITE [v]
 
@@ -22,7 +22,7 @@ v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     khronhite 2.0
 

--- a/source/commands/line.rst
+++ b/source/commands/line.rst
@@ -9,7 +9,7 @@ line
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LINE [ON|OFF|Solid|Dotted|n] [FILL ON|OFF|pos_color/neg_color]
         [Increment [ON|OFF]] [List STANDARD|nlist]
@@ -53,7 +53,7 @@ LIST STANDARD
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     line solid increment off list standard
 
@@ -77,20 +77,20 @@ n也可能是不同的。
 
 选择依次变化的线型，从线型1开始：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> line 1 increment
 
 改变线型表使之包含线型3、5和1：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> line list 3 5 1
 
 使用 :doc:`/commands/plot2` 在同一个图形上绘制三个文件，第一个使用实线无符号，
 第二个没有线条，用三角符号，第三个无线条，用十字符号：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1 file2 file3
     SAC> line list 1 0 0 increment
@@ -100,7 +100,7 @@ n也可能是不同的。
 将地震图的正值部分涂上红色，负值部分涂上蓝色，如果线型为0，则涂色区域用
 黑色描边：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seis
     SAC> line 0 fill red/blue

--- a/source/commands/linefit.rst
+++ b/source/commands/linefit.rst
@@ -9,7 +9,7 @@ linefit
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LINEFIT
 
@@ -30,7 +30,7 @@ linefit
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seis
     SAC> linefit            # 线性拟合

--- a/source/commands/linlin.rst
+++ b/source/commands/linlin.rst
@@ -9,6 +9,6 @@ linlin
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LINLIN

--- a/source/commands/linlog.rst
+++ b/source/commands/linlog.rst
@@ -9,6 +9,6 @@ linlog
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LINLOG

--- a/source/commands/listhdr.rst
+++ b/source/commands/listhdr.rst
@@ -9,7 +9,7 @@ listhdr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ListHdr [Default|Picks|SPecial] [FILES ALL|NONE|list] [COLUMNS 1|2]
         [INCLUSIVE ON|OFF] [hdrlist]
@@ -47,7 +47,7 @@ hdrlist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     listhdr default files all columns 1 inclusive off
 
@@ -68,36 +68,36 @@ hdrlist
 
 获取 ``picks`` 列表，输出为两列显示：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh picks column 2
 
 获得第三、四个文件的默认头段列表：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh files 3 4
 
 列出文件开始和结束时间：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh b e
 
 定义一个包含台站参数的特殊列表：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh kstnm stla stlo stel stdp
 
 稍后再次使用上面的特殊列表：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh special
 
 为后面的 ``lh`` 命令设置输出为两列：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lh columns 2 files none

--- a/source/commands/load.rst
+++ b/source/commands/load.rst
@@ -9,7 +9,7 @@ load
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LOAD comname [ABBREV abbrevname]
 
@@ -39,7 +39,7 @@ ABBREV abbrevname
 设置你的环境变量使得 SAC 在当前目录从库文件 ``libbar.so`` 中查找一个称为
 ``foo`` 的命令，并为 foo 设置别名为 myfft：
 
-.. code-block:: bash
+.. code-block:: console
 
     % export SACSOLIST = "libcom.so libbar.so"
     #  Add the current directory to the search path.
@@ -53,7 +53,7 @@ ABBREV abbrevname
 
 如何创建一个包含你的命令的共享目标库：
 
-.. code-block:: bash
+.. code-block:: console
 
     Solaris::
     cc -o libxxx.so -G extern.c foo.c bar.c

--- a/source/commands/loadctable.rst
+++ b/source/commands/loadctable.rst
@@ -9,7 +9,7 @@ loadctable
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LoadCTable n|[DIR CURRENT|name] [filelist]
 

--- a/source/commands/log.rst
+++ b/source/commands/log.rst
@@ -9,7 +9,7 @@ log
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LOG
 

--- a/source/commands/log10.rst
+++ b/source/commands/log10.rst
@@ -9,7 +9,7 @@ log10
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LOG10
 

--- a/source/commands/loglab.rst
+++ b/source/commands/loglab.rst
@@ -9,7 +9,7 @@ loglab
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LOGLAB [ON|OFF]
 
@@ -22,7 +22,7 @@ ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     loglab on
 

--- a/source/commands/loglin.rst
+++ b/source/commands/loglin.rst
@@ -9,6 +9,6 @@ loglin
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LOGLIN

--- a/source/commands/loglog.rst
+++ b/source/commands/loglog.rst
@@ -9,6 +9,6 @@ loglog
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LOGLOG

--- a/source/commands/lowpass.rst
+++ b/source/commands/lowpass.rst
@@ -9,7 +9,7 @@ lowpass
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     LowPass [BUtter|BEssel|C1|C2] [Corners v1 v2] [Npoles n] [Passes n]
         [Tranbw v] [Atten v]
@@ -47,7 +47,7 @@ ATTEN v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     lowpass butter corner 0.2 npoles 2 passes 1 tranbw 0.3 atten 30
 
@@ -61,13 +61,13 @@ ATTEN v
 
 应用一个四极 Butterworth，拐角频率为 2 Hz：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lp n 4 c 2
 
 在此之后如果要应用一个二极双通具有相同频率的 Bessel：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> lp n 2 be p 2
 

--- a/source/commands/macro.rst
+++ b/source/commands/macro.rst
@@ -9,7 +9,7 @@ macro
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Macro name [arguments]
 

--- a/source/commands/map.rst
+++ b/source/commands/map.rst
@@ -12,7 +12,7 @@ GMT 地图，也可以在命令行上指定一个事件文件。每个地震事�
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MAP [MERcator|EQuidistant|AZimuthal_equidistant|ROBinson]
         [WEST minlon] [EAST maxlon] [NORTH maxlat] [SOUTH minlat]
@@ -75,7 +75,7 @@ SAC中可以使用的投影方式包括：
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     map mercator topo off stan off file gmt.ps plotstations on
         plotevents on
@@ -85,7 +85,7 @@ SAC中可以使用的投影方式包括：
 
 利用SAC提供的一些数据作为例子：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> dg sub regional *.z
     SAC> title "Station Location Map"

--- a/source/commands/markptp.rst
+++ b/source/commands/markptp.rst
@@ -9,7 +9,7 @@ markptp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MARKPtp [Length v] [To marker]
 
@@ -27,7 +27,7 @@ TO marker
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     markptp length 5.0 to t0
 
@@ -57,7 +57,7 @@ TO marker
 
 设置测量时间窗为头段 ``T4`` 和 ``T5`` 之间，并使用默认的滑动时间窗长和时间标记：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mtw t4 t5
     SAC> markptp
@@ -65,7 +65,7 @@ TO marker
 
 设置测量时间窗为初动之后的 30 s，滑动时间窗为 3 s，起始时间标记为 ``T7``\ ：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mtw a 0 30
     SAC> markptp l 3. to t7

--- a/source/commands/marktimes.rst
+++ b/source/commands/marktimes.rst
@@ -9,7 +9,7 @@ marktimes
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MARKTimes [To marker] [Distance Header|v] [Origin Header|v|GMT time]
         [Velocities v ... ]
@@ -47,7 +47,7 @@ VELOCITIES v ...
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     marktimes velocities 2. 3. 4. 5. 6. distance header origin header to t0
 
@@ -66,19 +66,19 @@ VELOCITIES v ...
 
 使用默认的速度集，强制距离为 340 km，第一个时间标记为 ``T4``\ ：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> marktimes distance 340. to t4
 
 选择一个不同的速度集：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> markt v 3.5 4.0 4.5 5.0 5.5
 
 设置新的参考时间并将结果保存在 ``T2`` 中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> markt origin gmt 1984 231 12 43 17 237 to t2
 

--- a/source/commands/markvalue.rst
+++ b/source/commands/markvalue.rst
@@ -9,7 +9,7 @@ markvalue
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MARKValue [GE|LE v] [TO marker]
 
@@ -28,7 +28,7 @@ TO marker
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     markvalue ge 1 to t0
 
@@ -44,13 +44,13 @@ TO marker
 
 搜索文件中第一个值大于 3.4 的点并将结果保存在头段 ``T7`` 中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> markvalue ge 3.4 to t7
 
 设定测量时间窗为 ``T4`` 后的10秒，并搜索第一个小于-3的值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mtw t4 0 10
     SAC> markvalue le -3 to t5

--- a/source/commands/mathop.rst
+++ b/source/commands/mathop.rst
@@ -9,7 +9,7 @@ mathop
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MATHOP NORMAL|MATH|FORTRAN|NONE|OLD
 
@@ -25,7 +25,7 @@ NONE|OLD
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     mathop NORMAL
 
@@ -47,7 +47,7 @@ SAC在101.6之后的版本中，默认使用正常的操作符优先级。对于
 
 正常的操作符优先级：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mathop normal
     SAC> eval 1+2*3
@@ -57,7 +57,7 @@ SAC在101.6之后的版本中，默认使用正常的操作符优先级。对于
 
 旧的操作符优先级：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mathop old
     SAC> eval 1+2*3

--- a/source/commands/merge.rst
+++ b/source/commands/merge.rst
@@ -9,7 +9,7 @@ merge
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MERGE [Verbose] [Gap Zero|Interp] [Overlap Compare|Average] [filelist]
 
@@ -63,7 +63,7 @@ v101.6之后的新版 ``merge`` 命令，会将内存中的全部数据文件以
 
 下面看一个数据合并的示例：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1 file2
     SAC> merge file3 file4
@@ -78,7 +78,7 @@ file4 与 file2 合并成文件 file2，此时内存中有两个文件 file1 和
 
 多个文件合并成单个文件的一种方法：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1                        # 读取一个文件
     SAC> merge file2 file3 file4        # merge 其余文件
@@ -86,7 +86,7 @@ file4 与 file2 合并成文件 file2，此时内存中有两个文件 file1 和
 
 另一种合并办法：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r file1 file2 file3 file4
     SAC> merge                      # 合并内存中的所有文件
@@ -94,7 +94,7 @@ file4 与 file2 合并成文件 file2，此时内存中有两个文件 file1 和
 
 再一种合并方法：
 
-.. code-block:: bash
+.. code-block:: console
 
                                         # 内存中无数据
     SAC> merge file1 file2 file3 file4  # 合并 filelist 中的全部文件

--- a/source/commands/message.rst
+++ b/source/commands/message.rst
@@ -9,7 +9,7 @@ message
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MESsage text
 
@@ -30,14 +30,14 @@ text
 
 发送无空格的信息：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> message finished
      finished
 
 发送带有空格的信息，需要加上单引号或双引号：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> message 'Job has finished.'
      Job has finished.

--- a/source/commands/mtw.rst
+++ b/source/commands/mtw.rst
@@ -9,7 +9,7 @@ mtw
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MTW [ON|OFF|pdw]
 
@@ -28,7 +28,7 @@ pdw
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     mtw off
 

--- a/source/commands/mul.rst
+++ b/source/commands/mul.rst
@@ -9,7 +9,7 @@ mul
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MUL [v1 [v2 ... vn]]
 
@@ -28,7 +28,7 @@ vn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     mul 1.0
 

--- a/source/commands/mulf.rst
+++ b/source/commands/mulf.rst
@@ -9,7 +9,7 @@ mulf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MULF [NEWHDR [ON|OFF]] filelist
 

--- a/source/commands/mulomega.rst
+++ b/source/commands/mulomega.rst
@@ -9,7 +9,7 @@ mulomega
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     MULOMEGA
 

--- a/source/commands/news.rst
+++ b/source/commands/news.rst
@@ -9,7 +9,7 @@ news
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     NEWS
 

--- a/source/commands/null.rst
+++ b/source/commands/null.rst
@@ -9,7 +9,7 @@ null
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     NULL [ON|OFF|value]
 
@@ -28,7 +28,7 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     null off
 
@@ -44,6 +44,6 @@ OFF
 
 设置空值为-1.0并打开空值选项：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> null on -1.0

--- a/source/commands/oapf.rst
+++ b/source/commands/oapf.rst
@@ -9,7 +9,7 @@ oapf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     OAPF [STANDARD|NAME] [file]
 
@@ -30,7 +30,7 @@ file
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     oapf standard apf
 

--- a/source/commands/ohpf.rst
+++ b/source/commands/ohpf.rst
@@ -9,7 +9,7 @@ ohpf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     OHPF [file]
 
@@ -22,7 +22,7 @@ file
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     OHPF HPF
 

--- a/source/commands/pause.rst
+++ b/source/commands/pause.rst
@@ -9,7 +9,7 @@ pause
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PAUSE [MESSAGE text] [PERIOD ON|OFF|v]
 
@@ -32,7 +32,7 @@ PERIOD OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     pause message 'Pausing' period off
 

--- a/source/commands/pickauthor.rst
+++ b/source/commands/pickauthor.rst
@@ -10,7 +10,7 @@ pickauthor
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PICKAuthor author1 [author2 author3 ...]
     PICKAuthor FILE [filename]
@@ -34,7 +34,7 @@ PHASE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     pickauthor file
 

--- a/source/commands/pickphase.rst
+++ b/source/commands/pickphase.rst
@@ -10,7 +10,7 @@ pickphase
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PICKPHase header phase author [header phase author ...]
     PICKPHase FILE [filename]
@@ -40,7 +40,7 @@ AUTHOR
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     pickphase file
 

--- a/source/commands/pickprefs.rst
+++ b/source/commands/pickprefs.rst
@@ -12,7 +12,7 @@ SAC 将使用 :doc:`/commands/readcss` 命令中描述的参考文件
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PICKPRefs ON|OFF
 
@@ -30,7 +30,7 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     pickprefs off
 

--- a/source/commands/picks.rst
+++ b/source/commands/picks.rst
@@ -9,7 +9,7 @@ picks
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PICKS [ON|OFF] [pick Vertical|Horizontal|Cross] [Width v] [Height v]
 
@@ -41,7 +41,7 @@ HEIGHT v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     picks on width 0.1 height 0.1
 
@@ -63,7 +63,7 @@ HEIGHT v
 
 以交叉线显示时间标记 ``T4``\ 、\ ``T5`` 和 ``T6``\ ，并改变交叉线的高度和宽度：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> picks t4 c t5 c t6 c w 0.3 h 0.1
 

--- a/source/commands/plabel.rst
+++ b/source/commands/plabel.rst
@@ -9,7 +9,7 @@ plabel
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PLABEL [n] [ON|OFF|text] [Size Tiny|Small|Medium|Large]
         [Below|Position x y [a]]
@@ -59,7 +59,7 @@ POSITION x y a
 
 为绘图定义一系列标签：
 
-.. code-block:: bash
+.. code-block:: console
 
     # 三行标签
     SAC> dg sub local cdv.z

--- a/source/commands/plot.rst
+++ b/source/commands/plot.rst
@@ -9,7 +9,7 @@ plot
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Plot
 

--- a/source/commands/plot1.rst
+++ b/source/commands/plot1.rst
@@ -9,7 +9,7 @@ plot1
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Plot1 [Absolute|Relative] [Perplot ON|OFF|n]
 
@@ -31,7 +31,7 @@ PERPLOT OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     plot1 absolute perplot off
 
@@ -58,7 +58,7 @@ PERPLOT OFF
 下面的例子是由 LLNL DSS 的4个台站 Elko、Kanab、Landers 和 Mina 记录到的美国
 西部的一个地震。参考时间为事件发生时刻：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> cut -5 200
     SAC> read *v

--- a/source/commands/plot2.rst
+++ b/source/commands/plot2.rst
@@ -9,7 +9,7 @@ plot2
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Plot2 [Absolute|Relative]
 
@@ -22,7 +22,7 @@ ABSOLUTE|RELATIVE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     p2 absolute
 
@@ -59,7 +59,7 @@ Nqquist频率以及频率间隔 ``df``\ 。头段值 ``depmin`` 和 ``depmax``
 示例
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read mnv.z.am knb.z.am elk.z.am
     SAC> xlim 0.04 0.16

--- a/source/commands/plotalpha.rst
+++ b/source/commands/plotalpha.rst
@@ -9,7 +9,7 @@ plotalpha
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PlotAlpha [MORE] [DIR CURRENT|name] [FREE|FORMAT text] [CONTENT text] [filelist]
 
@@ -42,7 +42,7 @@ filelist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     plotalpha free content y. dir current
 
@@ -57,6 +57,6 @@ filelist
 
 读取并绘制一个自由格式的X-Y数据，且其第一个字段是标签：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> plotalpha content lp filea

--- a/source/commands/plotc.rst
+++ b/source/commands/plotc.rst
@@ -9,7 +9,7 @@ plotc
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PlotC [Replay|Create] [File|Macro filename] [Border ON|OFF]
 
@@ -34,7 +34,7 @@ BORDER ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     plotc create file out border on
 
@@ -80,7 +80,7 @@ BORDER ON|OFF
 
 下面的例子展示了如何使用 ``plotc`` 命令给一个 SAC 标准绘图添加注释：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg impulse npts 1024                     # 生成文件
     SAC> lp c2 n 7 c 0.2 t 0.25 a 10              # 低通滤波
@@ -106,7 +106,7 @@ BORDER ON|OFF
 
 为了将注释写入SGF文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> begindevices sgf                  # 打开 sgf 设备
     SAC> beginframe

--- a/source/commands/plotdy.rst
+++ b/source/commands/plotdy.rst
@@ -9,7 +9,7 @@ plotdy
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PLOTDY [ASPECT ON|OFF] name|number [name|number]
 
@@ -39,7 +39,7 @@ number
 假定你有一个等间距的 ASCII 文件，其包含了两列数据。第一列是y值，第二列是
 dy 值，你可以像下面那样读入 SAC 并用数据绘制误差棒：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readtable content yy myfile
     SAC> plotdy 1 2

--- a/source/commands/plotpk.rst
+++ b/source/commands/plotpk.rst
@@ -9,7 +9,7 @@ plotpk
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PlotPK [Perplot ON|OFF|n] [Bell ON|OFF] [Absolute|Relative]
         [REFerence ON|OFF|v] [Markall ON|OFF] [Saveloc ON|OFF]
@@ -51,7 +51,7 @@ SAVELOCS ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     plotpk perplot off absolute reference off markall off savelocs off
 
@@ -98,7 +98,7 @@ BUGS
 
    示例代码如下：
 
-   .. code-block:: bash
+   .. code-block:: console
 
        SAC> dg sub local cdv.z
        SAC> w 1.SAC

--- a/source/commands/plotpm.rst
+++ b/source/commands/plotpm.rst
@@ -9,7 +9,7 @@ plotpm
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PlotPM
 
@@ -31,7 +31,7 @@ plotpm
 
 创建一个两个地震图的质点运动图：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read xyz.t xyz.r
     SAC> xlabel 'radial component'
@@ -42,7 +42,7 @@ plotpm
 如果你想要值绘制每个文件在初动附近的一部分，你可以使用
 :doc:`/commands/xlim` 命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> xlim a -0.2 2.0
     SAC> PLOTPM
@@ -50,7 +50,7 @@ plotpm
 也可以使用 :doc:`/commands/plotpk` 在之前的绘图窗口中设置新的区域，然后绘制
 命令如下：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> beginwindow 2
     SAC> plotpk

--- a/source/commands/plotsp.rst
+++ b/source/commands/plotsp.rst
@@ -9,7 +9,7 @@ plotsp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PlotSP [ASIS|RLIM|AMPH|RL|IM|AM|PH] [LINLIN|LINLOG|LOGLIN|LOGLOG]
 
@@ -35,7 +35,7 @@ LINLIN|LINLOG|LOGLIN|LOGLOG
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     plotsp asis loglog
 
@@ -53,7 +53,7 @@ SAC 数据文件可能包含时间序列文件或谱文件，\ ``IFTYPE`` 决定
 
 获得一个谱文件振幅的对数-线性的绘图：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1
     SAC> fft

--- a/source/commands/plotxy.rst
+++ b/source/commands/plotxy.rst
@@ -9,7 +9,7 @@ plotxy
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PlotXY name|number name|number [name|number ...]
 
@@ -39,7 +39,7 @@ number
 读入这个文件，将其储存为 SAC 内部4个分开的文件，打开线型增量开关，然后以
 第二列为自变量，其他列为因变量绘图：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readalpha content ynnn myfile
     SAC> line increment on

--- a/source/commands/print.rst
+++ b/source/commands/print.rst
@@ -9,7 +9,7 @@ print
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PRINT [printer]
 

--- a/source/commands/printhelp.rst
+++ b/source/commands/printhelp.rst
@@ -9,7 +9,7 @@ printhelp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PrintHelp [item ...]
 

--- a/source/commands/production.rst
+++ b/source/commands/production.rst
@@ -9,7 +9,7 @@ production
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     PRODuction ON|OFF
 
@@ -22,7 +22,7 @@ ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     production off
 

--- a/source/commands/qdp.rst
+++ b/source/commands/qdp.rst
@@ -9,7 +9,7 @@ qdp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     QDP [ON|OFF|n] [TERM ON|OFF|n] [SGF ON|OFF|n]
 
@@ -37,7 +37,7 @@ SGF n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     qdp term 5000 sgf 5000
 
@@ -60,7 +60,7 @@ plot” 选项绘制数据文件的部分数据点的方式来加速绘图。
 
 假设文件 FILE1 有20000个数据点，文件 FILE2 有40000个数据点，如果你输入：
 
-.. code-block:: bash
+.. code-block:: console
 
     sac> r file1 file2
     sac> p
@@ -70,7 +70,7 @@ plot” 选项绘制数据文件的部分数据点的方式来加速绘图。
 
 如果想要绘制全部数据点，则需要关闭 QDP 选项：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> qdp off
     SAC> p

--- a/source/commands/quantize.rst
+++ b/source/commands/quantize.rst
@@ -9,7 +9,7 @@ quantize
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     QUANTIZE [GAINS n ...] [LEVEL v] [MANTISSA n]
 
@@ -28,7 +28,7 @@ MANTISSA n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     quantize gains 128 32 8 1 level 0.00001 mantissa 14
 

--- a/source/commands/quit.rst
+++ b/source/commands/quit.rst
@@ -9,7 +9,7 @@ quit
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Quit
 

--- a/source/commands/quitsub.rst
+++ b/source/commands/quitsub.rst
@@ -9,7 +9,7 @@ quitsub
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     QuitSub
 

--- a/source/commands/read.rst
+++ b/source/commands/read.rst
@@ -9,7 +9,7 @@ read
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Read [MORE] [DIR CURRENT|name] [XDR|ALPHA|SEGY] [SCALE ON|OFF] [filelist]
 
@@ -50,7 +50,7 @@ filelist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     read dir current
 
@@ -79,7 +79,7 @@ filelist
 
 如果你想要对一个数据进行高通滤波，并与原始数据进行对比：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r f01
     SAC> hp c 1.3 n 6
@@ -89,25 +89,25 @@ filelist
 假设SAC的启动目录位于 ``/me/data``\ ，你想要处理其子目录 ``event1`` 和
 ``event2`` 下的文件。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read dir event1 f01 f02
 
 读取了目录 ``/me/data/event1`` 下的文件。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read f03 g03
 
 相同目录下的文件被读入。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read dir event2 *
 
 ``/me/data/event2`` 下的全部文件被读入。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read dir current f03 g03
 

--- a/source/commands/readbbf.rst
+++ b/source/commands/readbbf.rst
@@ -9,7 +9,7 @@ readbbf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ReadBBF [file]
 
@@ -22,7 +22,7 @@ file
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     readbbf bbf
 

--- a/source/commands/readcss.rst
+++ b/source/commands/readcss.rst
@@ -9,7 +9,7 @@ readcss
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ReadCSS [BINARY|ASCII] [MAXmem v] [MORE] [TRUST ON|OFF] [VERbose ON|OFF]
         [SHIFT ON|OFF] [SCALE ON|OFF] [MAGnitude MB|MS|ML|DEF] [DIR name] wfdisclist
@@ -18,7 +18,7 @@ readcss
 其中 ``cssoptions`` 用于进一步从 ``wfdisc`` 文件中筛选满足条件的数据文件，
 ``cssoptions`` 可以取：
 
-.. code-block:: bash
+.. code-block:: console
 
         [STAtion station] [CHANnel channel] [BANDwidth bandcode]
         [ORIENTation orientation-code]
@@ -104,7 +104,7 @@ ORIENTATION orientation-code
 默认值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     readcss ascii maxmem 0.3 verbose off station * band * chan * orient
 

--- a/source/commands/readerr.rst
+++ b/source/commands/readerr.rst
@@ -9,7 +9,7 @@ readerr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ReadERR [Badfile Fatal|Warning|Ignore] [Nofiles Fatal|Warning|Ignore]
               [Memory Save|Delete]
@@ -44,7 +44,7 @@ SAVE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     readerr badfile warning nofiles fatal memory delete
 

--- a/source/commands/readhdr.rst
+++ b/source/commands/readhdr.rst
@@ -9,7 +9,7 @@ readhdr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ReadHdr [MORE] [DIR CURRENT|name] [filelist]
 

--- a/source/commands/readsp.rst
+++ b/source/commands/readsp.rst
@@ -9,7 +9,7 @@ readsp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ReadSP [AMPH|RLIM|SPE] [filelist]
 
@@ -31,7 +31,7 @@ filelist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     READSP AMPH
 

--- a/source/commands/readtable.rst
+++ b/source/commands/readtable.rst
@@ -9,7 +9,7 @@ readtable
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ReadTABle [MORE] [DIR CURRENT|name] [FREE|FORMAT tex] [CONTENT text]
         [HEADER number] [filelist]
@@ -47,7 +47,7 @@ filelist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     readtable free content y. dir current
 
@@ -87,7 +87,7 @@ filelist
 
 为了读取一个或多个自由格式的 X-Y 数据对：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readtable content p. filea
 
@@ -95,7 +95,7 @@ filelist
 在每行的中间有一个 X-Y 数据对。每行的其它数据都没有用。假设每行 Y 数据在 X 数据
 之前，一旦正确的格式声明给出了，就可以用下面的命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readtable content r format \(24x,f12.3,14x,f10.2\) fileb
 
@@ -106,7 +106,7 @@ SAC 使用括号作为内联函数。由于没有重复计数器，因而只有�
 假设你有一个文件 FILEC，其每行包括一个 X 值和7个不同数据集的 Y 值，其为
 ``(8F10.2)`` 格式。为了在内存中创建7个不同的数据集，可以使用下面的命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readtable content xn . format \(8f10.2\) filec
 
@@ -114,13 +114,13 @@ SAC 使用括号作为内联函数。由于没有重复计数器，因而只有�
 
 现在假设你不想读入第5个 Y 数据集，可以执行下面的命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readtable content xn6 format \(5f10.20x,2f10.2\) filec
 
 另一个可以少敲键盘但是稍微低效一点的命令如下：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readtable content xn4in2 format \(8f10.2\) filec
 

--- a/source/commands/report.rst
+++ b/source/commands/report.rst
@@ -9,7 +9,7 @@ report
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     REPort APF|COLOR|CUT|DEVICES|FILEID|GTEXT|HPF|LINE|MEMORY|MTW|PICKS|
         SYMBOL|TITLE|XLABEL|XLIM|YLABEL|YLIM
@@ -78,7 +78,7 @@ YLIM
 
 为了获取当前颜色属性的列表：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> report color
      COLOR option is ON
@@ -89,7 +89,7 @@ YLIM
 
 为了获取 HYPO 文件名：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> report apf hpf
      Alphanumeric pick file is MYPICKFILE

--- a/source/commands/reverse.rst
+++ b/source/commands/reverse.rst
@@ -9,6 +9,6 @@ reverse
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     REVERSE

--- a/source/commands/rglitches.rst
+++ b/source/commands/rglitches.rst
@@ -9,7 +9,7 @@ rglitches
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     RGLitches [THreshold v] [TYpe Linear|Zero] [Window ON|OFf|pdw]
         [METHOD Absolute|Power|Runavg]
@@ -52,7 +52,7 @@ MINAMP v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     rglitches threshold 1.0e+10 type linear window off method absolute
         swinlen 0.5 thresh2 5.0 minamp 50

--- a/source/commands/rmean.rst
+++ b/source/commands/rmean.rst
@@ -9,7 +9,7 @@ rmean
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     RMEAN
 

--- a/source/commands/rms.rst
+++ b/source/commands/rms.rst
@@ -9,7 +9,7 @@ rms
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     RMS [NOISE ON|OFF|pdw] [TO USERn]
 
@@ -28,7 +28,7 @@ TO USERn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     rms noise off to user0
 
@@ -60,14 +60,14 @@ TO USERn
 计算头段变量 ``T1`` 和 ``T2`` 之间的数据的未做噪声校正的均方根，
 并将结果保存在头段 ``USER4`` 中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mtw t1 t2
     SAC> rms to user4
 
 将 ``T3`` 前5秒作为噪声窗，计算校正噪声后的均方根：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> mtw t1 t2
     SAC> rms noise t3 -5.0 0.0

--- a/source/commands/rotate.rst
+++ b/source/commands/rotate.rst
@@ -9,7 +9,7 @@ rotate
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ROTate [TO Gcp|TO v|THrough v] [Normal|Reversed]
 
@@ -32,7 +32,7 @@ NORMAL|REVERSED
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     rotate to gcp normal
 
@@ -73,7 +73,7 @@ NORMAL|REVERSED
 
 将一对水平分量旋转 :math:`30^\circ`\ ：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> dg sub tele ntkl.[ne]          # 内存中的顺序是E分量先于N分量
     SAC> lh cmpinc cmpaz
@@ -106,7 +106,7 @@ NORMAL|REVERSED
 
 旋转两对水平分量到大圆弧路径：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read abc.n abc.e def.n def.e
     SAC> rotate to gcp

--- a/source/commands/rq.rst
+++ b/source/commands/rq.rst
@@ -9,7 +9,7 @@ rq
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     RQ [Q v] [R v] [C v]
 
@@ -28,7 +28,7 @@ C v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     rq q 1. r 0. c 1.
 

--- a/source/commands/rtrend.rst
+++ b/source/commands/rtrend.rst
@@ -9,7 +9,7 @@ rtrend
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     RTRend [Quiet|Verbose]
 
@@ -25,7 +25,7 @@ VERBOSE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     rtrend quiet
 

--- a/source/commands/saveimg.rst
+++ b/source/commands/saveimg.rst
@@ -9,7 +9,7 @@ saveimg
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SAVEimg filename.format
 
@@ -52,7 +52,7 @@ png 和 xpm 将拥有当前窗口的横纵比，pdf 或 ps 文件拥有固定的
 
 将图像保存为 PDF 文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read PAS.CI.BHZ.sac
     SAC> p1
@@ -60,7 +60,7 @@ png 和 xpm 将拥有当前窗口的横纵比，pdf 或 ps 文件拥有固定的
 
 将谱图用多种格式保存：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seismo
     SAC> spectrogram

--- a/source/commands/setbb.rst
+++ b/source/commands/setbb.rst
@@ -9,7 +9,7 @@ setbb
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SETBB variable [APPEND] value [variable [APPEND] value ...]
 
@@ -38,14 +38,14 @@ APPEND
 
 同时设置多个黑板变量，并在稍后使用使用这些黑板变量：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> setbb c1 2.45 c2 4.94
     SAC> bandpass corners %c1% %c2%
 
 黑板变量的值中包含空格：
 
-.. code-block:: bash
+.. code-block:: console
 
                                 # 含空格的值需要用引号括起来
     SAC> setbb mytitle 'sample filter response'

--- a/source/commands/setdevice.rst
+++ b/source/commands/setdevice.rst
@@ -9,7 +9,7 @@ setdevice
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SETDEVICE name
 

--- a/source/commands/setmacro.rst
+++ b/source/commands/setmacro.rst
@@ -9,7 +9,7 @@ setmacro
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SETMACRO [MORE] directory [directory ...]
 

--- a/source/commands/sgf.rst
+++ b/source/commands/sgf.rst
@@ -9,7 +9,7 @@ sgf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SGF [Prefix text] [Number n] [Directory CURRENT|pathname]
         [Size Normal|Fixed v|Scaled v] [Overwrite ON|OFF]
@@ -46,7 +46,7 @@ OVERWRITE ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     sgf prefix f number 1 directory current size normal
 
@@ -76,25 +76,25 @@ OVERWRITE ON|OFF
 
 设置 SGF 文件的保存目录为非当前目录，并重置 frame 编号：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> sgf dir /mydir/sgfstore frame 0
 
 设置 viewport 的 X 方向长度为3英寸：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> sgf size fixed 3.0
 
 创建一个大小相当于海报的图形：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> sgf size fixed 30.0
 
 设置 vierport 的 X 方向的尺寸与地震数据的时间长度成比例：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> sgf size scaled 0.1  # 10s的数据长度为1英寸
 

--- a/source/commands/smooth.rst
+++ b/source/commands/smooth.rst
@@ -9,7 +9,7 @@ smooth
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SMOOTH [MEAN|MEDIAN] [Halfwidth n]
 
@@ -25,7 +25,7 @@ HALFWIDTH n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     smooth mean halfwidth 1
 

--- a/source/commands/sonogram.rst
+++ b/source/commands/sonogram.rst
@@ -9,7 +9,7 @@ sonogram
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SONOgram [WINDOW v] [SLICE v] [ORDER n] [CBAR ON|OFF] [YMIN v] [YMAX v]
         [FMIN v] [FMAX v] [BINARY|FULL] [METHOD PDS|MEM|MLM] [COLOR|GRAY]
@@ -54,7 +54,7 @@ COLOR|GRAY
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     sonogram window 2 slice 1 method mem order 100 ymin 0 ymax fnyquist
         fmin 2.0 fmax 6.0 full color

--- a/source/commands/sort.rst
+++ b/source/commands/sort.rst
@@ -9,7 +9,7 @@ sort
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SORT header [ASCEND|DESCEND] [header [ASCEND|DESCEND]...]
 

--- a/source/commands/spectrogram.rst
+++ b/source/commands/spectrogram.rst
@@ -9,7 +9,7 @@ spectrogram
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SPectroGram [WINDOW v] [SLICE v] [ORDER n] [CBAR ON|OFF]
         [SQRT|NLOG|LOG10|NOSCALING] [YMIN v] [YMAX v] [METHOD PDS|MEM|MLM]
@@ -49,7 +49,7 @@ COLOR|GRAY
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     spectrogram window 2 slice 1 method mem order 100 noscaling
         ymin 0 ymax fnyquist color
@@ -70,7 +70,7 @@ COLOR|GRAY
 参数决定。沿着频谱图时间轴的谱之间的间隔由 ``slice``
 参数决定。这两个参数的不同决定了临近时间窗的重叠量，如下图所示:
 
-.. code-block:: bash
+.. code-block:: console
 
     Time ->
     0  1  2  3  4  5  6  7  8  9 10 11

--- a/source/commands/sqr.rst
+++ b/source/commands/sqr.rst
@@ -9,7 +9,7 @@ sqr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SQR
 

--- a/source/commands/sqrt.rst
+++ b/source/commands/sqrt.rst
@@ -9,7 +9,7 @@ sqrt
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SQRT
 

--- a/source/commands/stretch.rst
+++ b/source/commands/stretch.rst
@@ -9,7 +9,7 @@ stretch
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     STRETCH n [Filter ON|OFF]
 
@@ -25,7 +25,7 @@ FILTER ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     stretch 2 filter on
 

--- a/source/commands/sub.rst
+++ b/source/commands/sub.rst
@@ -9,7 +9,7 @@ sub
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SUB  [v1 [v2 ... vn]]
 
@@ -28,7 +28,7 @@ vn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     sub 0.0
 

--- a/source/commands/subf.rst
+++ b/source/commands/subf.rst
@@ -9,7 +9,7 @@ subf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SUBF [Newhdr [ON|OFF]] filelist
 

--- a/source/commands/symbol.rst
+++ b/source/commands/symbol.rst
@@ -9,7 +9,7 @@ symbol
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SYMbol [ON|OFF|n] [SIZE v] [SPACING v] [INCREment ON|OFF] [LIST STANDARD|nlist]
 
@@ -47,7 +47,7 @@ LIST STANDARD
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     symbol off size 0.01 spacing 0. increment off list standard
 
@@ -69,7 +69,7 @@ LIST STANDARD
 
 为了创建一个散点分布图，关闭画线选项，选择适当的符号，然后绘图：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> line off
     SAC> symbol 5
@@ -78,7 +78,7 @@ LIST STANDARD
 为了用符号7、4、6、8注释四条实线，间隔用0.3，用
 :doc:`/commands/plot2`  绘图：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> line solid
     SAC> sym spacing .3 increment list 7 4 6 8
@@ -88,7 +88,7 @@ LIST STANDARD
 使用 :doc:`/commands/plot2` 在相同图形上绘制三个文件，第一个文件图形使用
 实线无符号；第二个没有线，为三角符号；第三个没有线，带有交叉符号：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1 file2 file3
     SAC> line list 1 0 0 increment

--- a/source/commands/synchronize.rst
+++ b/source/commands/synchronize.rst
@@ -9,7 +9,7 @@ synchronize
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SYNChronize [Round ON|OFF] [Begin ON|OFF]
 
@@ -32,7 +32,7 @@ BEGIN OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     synchronize round off begin off
 
@@ -57,7 +57,7 @@ BEGIN OFF
 
 假定你读取两个不同参考时间的文件到内存：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1 file2
     SAC> listhdr b kztime kzdate
@@ -77,7 +77,7 @@ BEGIN OFF
 这些文件有相同的参考日期，不同的参考时刻以及不同的开始时间偏移量。可以
 执行 ``synchronize`` 同步参考时刻：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> synchronize
     SAC> listhdr

--- a/source/commands/systemcommand.rst
+++ b/source/commands/systemcommand.rst
@@ -9,7 +9,7 @@ systemcommand
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     SystemCommand command [options]
 
@@ -42,7 +42,7 @@ options
 
 调用系统命令 ``rm`` 删除某些 SAC 文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> rm junks           # 无法直接调用 rm 命令
      ERROR 1106: Not a valid SAC command.

--- a/source/commands/taper.rst
+++ b/source/commands/taper.rst
@@ -9,7 +9,7 @@ taper
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TAPER [Type HANning|HAMming|Cosine] [Width v]
 
@@ -25,7 +25,7 @@ WIDTH v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     taper type hanning width 0.05
 

--- a/source/commands/ticks.rst
+++ b/source/commands/ticks.rst
@@ -9,7 +9,7 @@ ticks
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TICKS [ON|OFF|ONLY] [All] [Top] [Bottom] [Right] [Left]
 
@@ -43,7 +43,7 @@ LEFT
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     ticks on all
 
@@ -57,18 +57,18 @@ LEFT
 
 显示上部刻度轴，其他不变：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ticks on top
 
 关闭所有刻度轴：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ticks off all
 
 只显示底部刻度轴：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ticks only bottom

--- a/source/commands/title.rst
+++ b/source/commands/title.rst
@@ -9,7 +9,7 @@ title
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TITLE [ON|OFF|text] [Location Top|Bottom|Right|Left]
         [Size Tiny|Small|Medium|Large]
@@ -37,7 +37,7 @@ SIZE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     title off location top size small
 

--- a/source/commands/trace.rst
+++ b/source/commands/trace.rst
@@ -9,7 +9,7 @@ trace
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TRACE [ON|OFF] name [name ...]
 
@@ -27,7 +27,7 @@ name
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     trace on
 
@@ -45,7 +45,7 @@ name
 
 追踪黑板变量 TEMP1 和文件 MYFILE 的头段变量 ``T0``\ ：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> trace on temp1 myfile,t0
       TRACE  (on) TEMP1 = 1.45623
@@ -55,20 +55,20 @@ name
 假设在完成一些计算之后改变了 TEMP1，并定义了 ``T0`` 的值，则 SAC 将
 显示如下信息：
 
-.. code-block:: bash
+.. code-block:: console
 
       TRACE (mod) TEMP1 = 2.34293
       TRACE (mod) MYFILE,T0 = 10.3451
 
 稍后的处理中 TEMP1 可能再次改变：
 
-.. code-block:: bash
+.. code-block:: console
 
       TRACE (mod) TEMP1 = 1.93242
 
 当跟踪选项被关闭时，SAC 最后一次显示变量当前值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> trace off temp1 myfile,t0
       TRACE (off) TEMP1 = 1.93242

--- a/source/commands/transcript.rst
+++ b/source/commands/transcript.rst
@@ -9,7 +9,7 @@ transcript
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TRANSCRIPT [OPEN|CREATE|CLOSE|CHANGE|WRITE|HISTORY] [FILE filename]
         [CONTENTS ALL|Errors|Warnings|Output|Commands|Macros|Processed]
@@ -67,7 +67,7 @@ CONTENTS PROCESSED
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     transcript open file transcript contents all
 
@@ -84,19 +84,19 @@ CONTENTS PROCESSED
 创建一个新的副本文件，文件名为 ``mytran``\ ，包含了除已处理命令之外的其他
 全部输出内容：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> transcript create file mytran cont err warn out com macros
 
 若之后不想把宏命令送入这个副本文件中，则可以使用 ``CHANGE`` 选项：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> transcript change file mytran contents e w o c
 
 定义一个名为 ``myrecord`` 的副本文件，其记录了终端输入的命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> transcript create file myrecord contents commands
 
@@ -105,7 +105,7 @@ CONTENTS PROCESSED
 假设你需要彻夜处理许多事件。你可以设置每个事件一个副本文件（用不同的副本文件名）
 去记录处理的结果。另外你可以将处理所有事件得到的任何错误消息保存到一个副本文件中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> transcript open file errortran contents errors
     SAC> transcript write message 'processing event 1'
@@ -116,7 +116,7 @@ CONTENTS PROCESSED
 
 为了保存一个命令行副本，以记录SAC当前和将来要运行的命令：
 
-.. code-block:: bash
+.. code-block:: console
 
     SCA> transcript history file .sachist
 

--- a/source/commands/transfer.rst
+++ b/source/commands/transfer.rst
@@ -9,7 +9,7 @@ transfer
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TRANSfer [FROM type [options]] [TO type [options]] [FREQlimits f1 f2 f3 f4]
         [PREWHitening ON|OFF|n]
@@ -32,7 +32,7 @@ PREWHITENING ON|OFF|n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     trans from none to none
 
@@ -130,7 +130,7 @@ SAC中内置了一堆预定义的仪器类型，可以在命令中直接使用�
 
 从数据中去除 LLL 宽频带仪器响应。并卷积上 SRO 仪器响应，且对频带做尖灭及预白化：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read abc.z
     SAC> rmean; rtr; taper
@@ -138,7 +138,7 @@ SAC中内置了一堆预定义的仪器类型，可以在命令中直接使用�
 
 当前的仪器类型为 RSTN 的子类型 nykm.z，为了去除该仪器响应并卷积上 DSS 仪器响应：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read nykm.z
     SAC> rmean; rtr; taper
@@ -146,14 +146,14 @@ SAC中内置了一堆预定义的仪器类型，可以在命令中直接使用�
 
 将电磁仪器响应转换成位移：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r XYZ.Z
     SAC> trans from elmag freep 15. mag 750. to none
 
 从波形中去除 WWSP 的仪器响应，得到位移波形：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read xyz.z
     SAC> rmean; rtr; taper
@@ -162,7 +162,7 @@ SAC中内置了一堆预定义的仪器类型，可以在命令中直接使用�
 
 向合成的位移地震图中加入 WWSP 仪器响应：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r syn.z
     SAC> trans from none to WWSP    # 简写为 trans to WWSP
@@ -179,7 +179,7 @@ evalresp 类型
 （比如“RESP.IU.COLA..BHZ”），并检测 RESP 文件中给出的台站信息是否与数据
 中的台站信息匹配\ [1]_。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r 2006.253.14.30.24.0000.TA.N11A..LHZ.Q.SAC
     SAC> rtr; rtr; taper
@@ -206,7 +206,7 @@ RESP文件 ``RESP.IU.COLA..BHZ``\ 。为了给所有台站去除仪器响应，�
 并修改 RESP 文件中的台站信息。显然，这样很麻烦，利用上面的选项可以大大简化
 这一过程：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r *.IU.*.BHZ
     SAC> rmean; rtr; taper
@@ -217,7 +217,7 @@ RESP文件 ``RESP.IU.COLA..BHZ``\ 。为了给所有台站去除仪器响应，�
 
 下面的命令会将三分量数据去仪器响应，并卷积上 BHZ 分量的仪器响应：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r *.IU.COLA.00.BH?
     SAC> rmean; rtr; taper
@@ -228,7 +228,7 @@ RESP文件 ``RESP.IU.COLA..BHZ``\ 。为了给所有台站去除仪器响应，�
 
 为了显示 IU 台网 COL 台站 BHZ通道，1992年01月02日16:42:05的仪器响应：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg impulse npts 16384 delta .05 begin 0.
     SAC> trans to evalresp sta COL cha BHZ net IU \
@@ -239,7 +239,7 @@ RESP文件 ``RESP.IU.COLA..BHZ``\ 。为了给所有台站去除仪器响应，�
 如果你的 RESP 文件名与 SAC 的标准格式不同，可以使用 ``FNAME`` 选项强制
 指定要使用的 RESP 文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r 2006.253.14.30.24.0000.TA.N11A..LHZ.Q.SAC
     SAC> rmean; rtr; taper
@@ -254,7 +254,7 @@ RESP文件 ``RESP.IU.COLA..BHZ``\ 。为了给所有台站去除仪器响应，�
 由于一个 RESP 文件中可以包含多个响应函数，因而可以将所有仪器响应文件合并到
 一个总的 RESP 文件中：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r *.SAC
     SAC> rmean; rtr; taper
@@ -276,7 +276,7 @@ PZ 文件，用户必须使用 ``subtype`` 来指定要使用的 PZ 文件。若
 有注释行，则注释行中的台站信息必须与波形中的台站信息匹配，才能正确执行；
 若 PZ 文件中无注释行，则不进行台站信息匹配的检测，直接执行。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r *IU.COLA.BHZ
     SAC> rmean; rtr; taper
@@ -286,7 +286,7 @@ PZ 文件，用户必须使用 ``subtype`` 来指定要使用的 PZ 文件。若
 PZ 文件合并得到总的PZ文件。下面的例子中读入全部波形数据，并利用总 PZ 文件
 进行去仪器响应：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r *.SAC          # 读入全部数据
     SAC> rmean; rtr; taper
@@ -307,7 +307,7 @@ fap 选项表明使用 FAP 文件作为响应函数。
 0.006 Hz 到 0.2 Hz，要从波形 ``2006.253.14.30.24.0000.TA.N11A..LHZ.Q.SAC``
 中移除该仪器响应：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r 2006.253.14.30.24.0000.TA.N11A..LHZ.Q.SAC
     SAC> rtr

--- a/source/commands/traveltime.rst
+++ b/source/commands/traveltime.rst
@@ -9,7 +9,7 @@ traveltime
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TRAVELTIME [Model model] [PICKS n] [PHASE phaselist] [VERBOSE|QUIET] [M|KM]
 
@@ -38,7 +38,7 @@ M|KM
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     traveltime MODEL iasp91 KM PHASE P S Pn Pg Sn Sg
 
@@ -66,7 +66,7 @@ M|KM
 
 区域事件，使用默认震相列表：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seismo
     SAC> traveltime
@@ -85,7 +85,7 @@ M|KM
 上面的示例，只是计算了震相走时，不会写入到头段变量中。要将震相走时存储到
 头段变量中，需要使用 ``PICKS n``\ 选项：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> fg seismo
     SAC> traveltime picks 0 phase Pn Pg Sn Sg
@@ -105,7 +105,7 @@ M|KM
 
 ``rdseed v5.0`` 生成的波形数据，震源深度 ``evdp`` 的单位为 m：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> r 2008.052.14.16.03.0000.XC.OR075.00.LHZ.M.SAC
     SAC> lh evdp

--- a/source/commands/tsize.rst
+++ b/source/commands/tsize.rst
@@ -9,7 +9,7 @@ tsize
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     TSIZE [Tiny|Small|Medium|Large v ] [Ratio v] [OLD|NEW]
 
@@ -31,7 +31,7 @@ NEW
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     tsize ratio 1.0 new
 
@@ -75,7 +75,7 @@ SAC提供了四个标准尺寸：\ ``TINY``\ 、\ ``SMALL``\ 、\ ``MEDIUM`` 和
 
 为了改变 ``MEDIUM`` 的定义，并使用它创建一个特别尺寸的标题：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> tsize medium 0.35
     SAC> title 'rayleigh wave spectra' size medium
@@ -83,6 +83,6 @@ SAC提供了四个标准尺寸：\ ``TINY``\ 、\ ``SMALL``\ 、\ ``MEDIUM`` 和
 
 为了重置文本尺寸到其默认值：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> tsize new

--- a/source/commands/unsetbb.rst
+++ b/source/commands/unsetbb.rst
@@ -9,7 +9,7 @@ unsetbb
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     UNSETBB ALL|variable ...
 
@@ -27,12 +27,12 @@ variable
 
 一次删除多个黑板变量：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> unsetbb c1 c2 x
 
 删除所有黑板变量：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> unsetbb all

--- a/source/commands/unwrap.rst
+++ b/source/commands/unwrap.rst
@@ -9,7 +9,7 @@ unwrap
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     UNWRAP [Fill ON|OFF|n] [Intthr v] [Pvthr v]
 
@@ -31,7 +31,7 @@ PVTHR v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     unwrap fill off intthr 1.5 pvthr 0.5
 

--- a/source/commands/vspace.rst
+++ b/source/commands/vspace.rst
@@ -9,7 +9,7 @@ vspace
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     VSPace [FULL|v]
 
@@ -25,7 +25,7 @@ v
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     vspace full
 

--- a/source/commands/wait.rst
+++ b/source/commands/wait.rst
@@ -9,7 +9,7 @@ wait
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WAIT [Text ON|OFF] [Plots ON|OFF|Every]
 
@@ -28,7 +28,7 @@ PLOTS EVERY
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     wait text on plots on
 

--- a/source/commands/whiten.rst
+++ b/source/commands/whiten.rst
@@ -9,7 +9,7 @@ whiten
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WhITen n
 
@@ -24,7 +24,7 @@ n
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     whiten 6
 

--- a/source/commands/whpf.rst
+++ b/source/commands/whpf.rst
@@ -9,7 +9,7 @@ whpf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WHPF IC n m
 

--- a/source/commands/width.rst
+++ b/source/commands/width.rst
@@ -9,7 +9,7 @@ width
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WIDTH [ON|OFF|width] [SKeleton width] [Increment ON|OFF] [List Standard|widthlist]
 
@@ -46,7 +46,7 @@ INCREMENT OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     width off skeleton 1 increment off list standard
 
@@ -65,7 +65,7 @@ INCREMENT OFF
 文件后，都按照宽度表中的次序自动地变成另一个宽度。宽度值和次序在标准宽度
 表中为:
 
-.. code-block:: bash
+.. code-block:: console
 
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 
@@ -78,12 +78,12 @@ INCREMENT OFF
 
 选择自动变换的数据宽度起始值为1：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> width 1 increment
 
 边框宽度起始值为2，并按1、3、5的增量变化：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> width skeleton 2 increment list 1 3 5

--- a/source/commands/wiener.rst
+++ b/source/commands/wiener.rst
@@ -9,7 +9,7 @@ wiener
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WieNeR [Window pdw] [Ncoeff n] [MU OFF|ON|v] [EPSilon OFF|ON|e]
 
@@ -44,7 +44,7 @@ EPSILON ON|OFF|e
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     wiener window b 0 10 ncoeff 30 mu off epsilon off
 
@@ -64,13 +64,13 @@ EPSILON ON|OFF|e
 
 下面的命令将应用一个非自适应滤波器，将第一个十秒指定为数据窗：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> wiener window b 0 10 mu 0.
 
 下面命令将应用带40个系数的滤波器，指定设计窗为从文件开始到第一个到时前1秒：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> wiener ncoeff 40 window b a -1
 

--- a/source/commands/wild.rst
+++ b/source/commands/wild.rst
@@ -9,7 +9,7 @@ wild
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WILD [ECHO ON|OFF] [SINGLE char] [MULTIPLE char] [CONCATENATION chars]
 
@@ -88,14 +88,14 @@ SAC 使用通配符完成文件名的扩展，通常有几个步骤：
 
 假定当前目录中包含如下次序的文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     ABC DEF STA01E STA01N STA01Z STA02E STA02N STA02Z STA03Z
 
 同样假定扩展文件设置回显，下面显示怎样使用各种通配符去将上面文件表的
 一部分读入内存：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> READ S*
      STA01E STA01N STA01Z STA02E STA02N STA02Z STA03Z

--- a/source/commands/window.rst
+++ b/source/commands/window.rst
@@ -9,7 +9,7 @@ window
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WINdow n [Xsize xwmin xwmax] [Ysize ywmin ywmax] [ASPECT [value|ON|OFF]]
 
@@ -79,14 +79,14 @@ SAC 使用的 X11 图形系统支持多窗口绘图。\ ``beginwindow``\ 命令�
 
 设定图形窗口1的水平位置，垂直位置不变：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> window 1 x 0.25 0.85
     SAC> beginwindow 1
 
 在这种情况下，显式指定了 XSIZE，因而 ASPECT 被自动设置为 OFF。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> window 1 aspect 1.33 x 0.25 0.85
     SAC> beginwindow 1
@@ -94,7 +94,7 @@ SAC 使用的 X11 图形系统支持多窗口绘图。\ ``beginwindow``\ 命令�
 该命令与上面的命令相同，虽然设置了 aspect 的值，但由于指定了 XSIZE，因而 XSIZE
 具有更高的优先级。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> window 1 x 0.25 0.85 aspect 1.33
     SAC> beginwindow 1

--- a/source/commands/write.rst
+++ b/source/commands/write.rst
@@ -9,7 +9,7 @@ write
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     Write [SAC|ALPHA|XDR] [DIR OFF|CURRENT|name] [KSTCMP]
         [OVER|APPEND text|PREPEND text|DELETE text|CHANGE text1 text2] filelist
@@ -67,7 +67,7 @@ filelist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     write sac
 
@@ -96,7 +96,7 @@ filelist
 
 对一组数据文件进行滤波，然后将结果存入一组新数据文件：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read d1 d2 d3
     SAC> lowpass butter npoles 4
@@ -104,7 +104,7 @@ filelist
 
 也可以使用 ``CHANGE`` 选项完成这一操作：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read d1 d2 d3
     SAC> lowpass butter npoles 4
@@ -112,7 +112,7 @@ filelist
 
 若想要用滤波后的数据替换磁盘中的原始数据，则上例的第三行要变成：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> write over
 

--- a/source/commands/writebbf.rst
+++ b/source/commands/writebbf.rst
@@ -9,7 +9,7 @@ writebbf
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WriteBBF [file]
 
@@ -22,7 +22,7 @@ file
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     writebbf bbf
 

--- a/source/commands/writecss.rst
+++ b/source/commands/writecss.rst
@@ -9,7 +9,7 @@ writecss
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WriteCSS [Binary|Ascii] [DIR ON|OFF|CURRENT|name] name
 
@@ -44,7 +44,7 @@ name
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     wirtecss ascii dir off
 

--- a/source/commands/writehdr.rst
+++ b/source/commands/writehdr.rst
@@ -9,7 +9,7 @@ writehdr
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WriteHdr
 

--- a/source/commands/writesp.rst
+++ b/source/commands/writesp.rst
@@ -9,7 +9,7 @@ writesp
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     WriteSP [ASIS|RLIM|AMPH|RL|IM|AM|PH] [OVER|filelist]
 
@@ -34,7 +34,7 @@ filelist
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     writesp asis
 
@@ -65,7 +65,7 @@ SAC 数据文件可以为时间序列文件或谱文件。头段中的 ``IFTYPE`
 
 假设你想要对 FILE1 的谱文件振幅进行一些操作：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1
     SAC> fft amph
@@ -73,7 +73,7 @@ SAC 数据文件可以为时间序列文件或谱文件。头段中的 ``IFTYPE`
 
 SAC 将输出两个文件 FILE1.AM 和 FILE1.PH，现在可以对振幅文件进行操作：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> read file1.am
     SAC> ...perform operations.
@@ -81,7 +81,7 @@ SAC 将输出两个文件 FILE1.AM 和 FILE1.PH，现在可以对振幅文件进
 
 现在磁盘中的文件为修改后的谱文件，如果你想要重建 SAC 谱数据并进行反变换：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> readsp file1
     SAC> ifft

--- a/source/commands/xdiv.rst
+++ b/source/commands/xdiv.rst
@@ -9,7 +9,7 @@ xdiv
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XDIV [NIce|Increment v|NUmber n] [Power ON|OFF]
 
@@ -34,7 +34,7 @@ POWER OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xdiv nice power on
 

--- a/source/commands/xfudge.rst
+++ b/source/commands/xfudge.rst
@@ -9,7 +9,7 @@ xfudge
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XFUDGE [ON|OFF|v]
 
@@ -28,7 +28,7 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xfudge 0.03
 

--- a/source/commands/xfull.rst
+++ b/source/commands/xfull.rst
@@ -9,7 +9,7 @@ xfull
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XFULL [ON|OFF]
 
@@ -22,7 +22,7 @@ ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xfull on
 

--- a/source/commands/xgrid.rst
+++ b/source/commands/xgrid.rst
@@ -9,7 +9,7 @@ xgrid
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XGRID ON|OFF|Solid|Dotted
 
@@ -31,6 +31,6 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xgrid off

--- a/source/commands/xlabel.rst
+++ b/source/commands/xlabel.rst
@@ -9,7 +9,7 @@ xlabel
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XLABeL [ON|OFF|text] [Location Top|Bottom|Right|Left]
         [Size Tiny|Small|Medium|Large]
@@ -48,7 +48,7 @@ LARGE
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xlabel off location bottom size small
 

--- a/source/commands/xlim.rst
+++ b/source/commands/xlim.rst
@@ -9,7 +9,7 @@ xlim
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XLIM [ON|OFF|pdw|SIGNAL]
 
@@ -31,7 +31,7 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xlim off
 

--- a/source/commands/xlin.rst
+++ b/source/commands/xlin.rst
@@ -9,6 +9,6 @@ xlin
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XLIN

--- a/source/commands/xlog.rst
+++ b/source/commands/xlog.rst
@@ -9,6 +9,6 @@ xlog
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XLOG

--- a/source/commands/xvport.rst
+++ b/source/commands/xvport.rst
@@ -9,7 +9,7 @@ xvport
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     XVPort xvmin xvmax
 
@@ -25,7 +25,7 @@ xvmax
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     xvport 0.1 0.9
 

--- a/source/commands/ydiv.rst
+++ b/source/commands/ydiv.rst
@@ -9,7 +9,7 @@ ydiv
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YDIV [NIce|Increment v|NUmber n] [Power ON|OFF]
 

--- a/source/commands/yfudge.rst
+++ b/source/commands/yfudge.rst
@@ -9,7 +9,7 @@ yfudge
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YFUDGE [ON|OFF|v]
 

--- a/source/commands/yfull.rst
+++ b/source/commands/yfull.rst
@@ -9,7 +9,7 @@ yfull
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YFULL [ON|OFF]
 
@@ -22,7 +22,7 @@ ON|OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     yfull on
 

--- a/source/commands/ygrid.rst
+++ b/source/commands/ygrid.rst
@@ -9,7 +9,7 @@ ygrid
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YGRID ON|OFF|Solid|Dotted
 
@@ -31,6 +31,6 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     ygrid off

--- a/source/commands/ylabel.rst
+++ b/source/commands/ylabel.rst
@@ -9,7 +9,7 @@ ylabel
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YLABeL [ON|OFF|text] [Location Top|Bottom|Right|Left]
         [Size Tiny|Small|Medium|Large]

--- a/source/commands/ylim.rst
+++ b/source/commands/ylim.rst
@@ -9,7 +9,7 @@ ylim
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YLIM [ON|OFF|ALL|min max|PM v]
 
@@ -34,7 +34,7 @@ OFF
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     ylim off
 
@@ -56,7 +56,7 @@ file1 的 Y 轴范围为0.0到30.0，file2 的 Y 轴范围为内存中所有文�
 file3 的 Y 轴范围将限定为文件自身的最大、最小值。如果文件多于三个，则其余的
 所有文件都限定为文件自身的最大、最小值。
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> ylim 0.0 30.0 all off
     SAC> r file1 file2 file3

--- a/source/commands/ylin.rst
+++ b/source/commands/ylin.rst
@@ -9,6 +9,6 @@ ylin
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YLIN

--- a/source/commands/ylog.rst
+++ b/source/commands/ylog.rst
@@ -9,6 +9,6 @@ ylog
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YLOG

--- a/source/commands/yvport.rst
+++ b/source/commands/yvport.rst
@@ -9,7 +9,7 @@ yvport
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     YVPort yvmin yvmax
 
@@ -25,7 +25,7 @@ yvmax
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     yvport 0.1 0.9
 

--- a/source/commands/zcolors.rst
+++ b/source/commands/zcolors.rst
@@ -9,7 +9,7 @@ zcolors
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ZCOLORS [ON|OFF] LIST c1 c2 ... cn
 
@@ -32,7 +32,7 @@ cn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     zcolors off list red green blue
 

--- a/source/commands/zlabels.rst
+++ b/source/commands/zlabels.rst
@@ -9,7 +9,7 @@ zlabels
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ZLABELS [ON|OFF] [SPACING v1 [v2 [v3]]] [SIZE v] [ANGLE v] [LIST c1 c2 ... cn]
 
@@ -61,7 +61,7 @@ text
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     zlabels off spacing 0.1 0.2 0.3 size 0.0075 angle 45.0 list on
 

--- a/source/commands/zlevels.rst
+++ b/source/commands/zlevels.rst
@@ -9,7 +9,7 @@ zlevels
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ZLEVELS [SCALE] [RANGE v1 v2] [INCREMENT v] [NUMBER n] [LIST v1 v2 ... vn]
 
@@ -35,7 +35,7 @@ LIST v1 v2 .. vn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     zlevels scale number 20
 

--- a/source/commands/zlines.rst
+++ b/source/commands/zlines.rst
@@ -9,7 +9,7 @@ zlines
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ZLINES  [ON|OFF] [LIST n1 n2 ... nn] [REGIONS v1 v2 ... vn]
 
@@ -32,7 +32,7 @@ REGIONS v1 v2 .. vn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     zlines on list 1
 
@@ -41,12 +41,12 @@ REGIONS v1 v2 .. vn
 
 循环四种不同线型，建立等值线：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> zlines list 1 2 3 4
 
 设置虚线表示低于0.0等值线，实线表示高于0.0的等值线：
 
-.. code-block:: bash
+.. code-block:: console
 
     SAC> zlines list 2 1 regions 0.0

--- a/source/commands/zticks.rst
+++ b/source/commands/zticks.rst
@@ -9,7 +9,7 @@ zticks
 语法
 ----
 
-.. code-block:: bash
+.. code-block:: console
 
     ZTICKS [ON|OFF] [Spacing v] [LEngth v] [Direction DOWN|UP] [List c1 c2 ... cn]
 
@@ -37,7 +37,7 @@ LIST c1 c2 . cn
 缺省值
 ------
 
-.. code-block:: bash
+.. code-block:: console
 
     zticks off spacing 0.1 length 0.005 direction down list on
 


### PR DESCRIPTION
Address #194.

As mentioned in #194, this PR changes `.. code-block:: bash` to `.. code-block:: console` for all SAC commands. 

Other files will be updated later to make this PR easier for reviewing.