### PR TITLE
Update libncurses5 to libncurses6

### DIFF
--- a/source/install/linux-binary.rst
+++ b/source/install/linux-binary.rst
@@ -14,9 +14,7 @@ Linux 二进制安装
 
     $ sudo apt update
     $ sudo apt install libc6 libsm6 libice6 libxpm4 libx11-6
-    $ sudo apt install zlib1g libncurses5
-    # 如果是 Ubuntu 24.04, libncurses5需要替换成libncurse-dev和libncurses6
-    $ sudo apt install zlib1g libncurses-dev libncurses6
+    $ sudo apt install zlib1g libncurses6
 
 对于 CentOS/Fedora/RHEL：
 

--- a/source/install/linux-binary.rst
+++ b/source/install/linux-binary.rst
@@ -15,6 +15,8 @@ Linux 二进制安装
     $ sudo apt update
     $ sudo apt install libc6 libsm6 libice6 libxpm4 libx11-6
     $ sudo apt install zlib1g libncurses5
+    # 如果是 Ubuntu 24.04, libncurses5需要替换成libncurse5-dev
+    $ sudo apt install zlib1g libncurses5-dev
 
 对于 CentOS/Fedora/RHEL：
 

--- a/source/install/linux-binary.rst
+++ b/source/install/linux-binary.rst
@@ -15,8 +15,8 @@ Linux 二进制安装
     $ sudo apt update
     $ sudo apt install libc6 libsm6 libice6 libxpm4 libx11-6
     $ sudo apt install zlib1g libncurses5
-    # 如果是 Ubuntu 24.04, libncurses5需要替换成libncurse5-dev
-    $ sudo apt install zlib1g libncurses5-dev
+    # 如果是 Ubuntu 24.04, libncurses5需要替换成libncurse-dev和libncurses6
+    $ sudo apt install zlib1g libncurses-dev libncurses6
 
 对于 CentOS/Fedora/RHEL：
 


### PR DESCRIPTION
In Ubuntu 24.04, libncurses5 is no longer available and should be replaced with libncurses6.